### PR TITLE
remove redirect_uri from google auth body

### DIFF
--- a/app/api/api_v1/endpoints/auth.py
+++ b/app/api/api_v1/endpoints/auth.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Depends, Form, HTTPException, Security, status
 from firebase_admin import auth as firebase_auth
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.core.database import get_db
 from app.core.dependencies import SessionDep, VerifiedUserDep
 from app.main import api_key_header
@@ -75,7 +76,9 @@ async def google_auth(
     5. Returns login info in both cases
     """
     auth_service = AuthService(db)
-    return await auth_service.google_auth(code=request.code, redirect_uri=request.redirect_uri)
+    return await auth_service.google_auth(
+        code=request.code, redirect_uri=settings.GOOGLE_REDIRECT_URI
+    )
 
 
 @router.post("/complete-profile", response_model=CompleteProfileResponse)

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -3,7 +3,6 @@ from typing import Annotated, Dict, Optional
 from fastapi import UploadFile
 from pydantic import AfterValidator, BaseModel, ConfigDict, EmailStr, Field, field_validator
 
-from app.core.config import settings
 from app.schemas.user import validate_phone_number, validate_phone_region
 
 # validators
@@ -28,7 +27,6 @@ class PhoneAuthRequest(BaseModel):
 
 class GoogleAuthRequest(BaseModel):
     code: str
-    redirect_uri: str = Field(examples=[settings.GOOGLE_REDIRECT_URI])
 
 
 class UpdatePhoneRequest(BaseModel):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Google sign-in flow by using a server-configured redirect URI.
  * Request payload for Google authentication no longer requires a redirect_uri field.

* **Chores**
  * Reduced configuration coupling by removing unnecessary dependency on client-provided redirect URIs.

Note: Clients integrating Google authentication must remove redirect_uri from their request payloads. The server now handles redirection internally using its configured value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->